### PR TITLE
WIP: Ignore query param on route param match

### DIFF
--- a/src/trout/route.cljs
+++ b/src/trout/route.cljs
@@ -6,8 +6,11 @@
 
 (defn- with-trailing-slash [s]
   (if cfg/*allow-trailing-slashes*
-    (str s "(?:" cfg/*path-separator* "(?=$))?")
+    (str s "(?:" cfg/*path-separator* ")?")
     s))
+
+(defn- ignore-query-params [s]
+  (str s "(?:[^?]*)?"))
 
 (defn- prefixed [pathv]
   (if cfg/*prefix*
@@ -58,6 +61,7 @@
        (#(map segment->pattern %))
        (apply str)
        (with-trailing-slash)
+       (ignore-query-params)
        (#(str "^" % "$"))
        (re-pattern)))
 

--- a/test/trout/route_test.cljs
+++ b/test/trout/route_test.cljs
@@ -57,7 +57,11 @@
       (are [x y] (= (tr/match route x) y)
         "/test"  {0 "test"}
         "/a/b/c" {0 "a/b/c"}
-        ""       nil))))
+        ""       nil)))
+
+  (testing "ignores query params in route param capture"
+    (is (= (tr/match (tr/Route. [:foo] nil) "/test?query=param")
+           {:foo "test"}))))
 
 (deftest string-generation
   (testing "Correctly generates path strings from route + arguments"


### PR DESCRIPTION
# Problem
Matching a route `/share/:raffle-id` with this url "/share/1cjux2wijrksi?nickname=Party" will include the query param in the `:raffle-id` match

# TODO
- [ ] Figure out regex combination to pass tests